### PR TITLE
Fix UTF-8 encoding for email subjects with emoji and unicode characters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -477,20 +477,23 @@ Always prefer creating drafts that you can review and send manually.`,
           throw new Error(`Invalid recipient email address: ${to}`)
         }
 
+        // Build email following Gmail API working pattern
+        const subjectBase64 = Buffer.from(subject, 'utf-8').toString('base64')
         const messageParts = [
+          `Content-Type: text/plain; charset="UTF-8"`,
           `MIME-Version: 1.0`,
-          `Content-Type: text/plain; charset=UTF-8`,
+          `Content-Transfer-Encoding: 7bit`,
           `To: ${to}`,
         ]
 
         if (cc) messageParts.push(`Cc: ${cc}`)
         if (bcc) messageParts.push(`Bcc: ${bcc}`)
 
-        messageParts.push(`Subject: ${subject}`, "", body)
+        messageParts.push(`Subject: =?UTF-8?B?${subjectBase64}?=`, "", body)
 
-        const message = messageParts.join("\n")
+        const message = messageParts.join("\r\n")
 
-        const encodedMessage = Buffer.from(message)
+        const encodedMessage = Buffer.from(message, "utf-8")
           .toString("base64")
           .replace(/\+/g, "-")
           .replace(/\//g, "_")
@@ -729,7 +732,7 @@ ${cc ? `📄 CC: ${cc}\n` : ""}${bcc ? `🔒 BCC: ${bcc}\n` : ""}
           `Content-Type: text/plain; charset=UTF-8`,
           `Content-Transfer-Encoding: 8bit`,
           `To: ${replyToEmail}`,
-          `Subject: ${replySubject}`,
+          `Subject: =?UTF-8?B?${Buffer.from(replySubject, 'utf-8').toString('base64')}?=`,
           messageId ? `In-Reply-To: ${messageId}` : "",
           referencesHeader ? `References: ${referencesHeader}` : "",
           "",
@@ -821,13 +824,16 @@ Best regards`,
         const messageParts = [
           `MIME-Version: 1.0`,
           `Content-Type: text/plain; charset=UTF-8`,
+          `Content-Transfer-Encoding: 8bit`,
           `To: ${to}`,
         ]
 
         if (cc) messageParts.push(`Cc: ${cc}`)
         if (bcc) messageParts.push(`Bcc: ${bcc}`)
 
-        messageParts.push(`Subject: ${subject}`)
+        // RFC 2047 encoding for subject (required for emojis and unicode)
+        const subjectBase64 = Buffer.from(subject, 'utf-8').toString('base64')
+        messageParts.push(`Subject: =?UTF-8?B?${subjectBase64}?=`)
 
         // Add threading headers if provided
         let threadingInfo = ""
@@ -844,9 +850,9 @@ Best regards`,
         // Add empty line before body
         messageParts.push("", body)
 
-        const message = messageParts.join("\n")
+        const message = messageParts.join("\r\n")
 
-        const encodedMessage = Buffer.from(message)
+        const encodedMessage = Buffer.from(message, "utf-8")
           .toString("base64")
           .replace(/\+/g, "-")
           .replace(/\//g, "_")


### PR DESCRIPTION
## 🐛 Problem

Email subjects containing emoji or unicode characters were being corrupted when sent via Gmail API. For example:
- `🤖 Test Email ¡Hola\!` was appearing as `Ã°ÂŸÂ¤Â– Test Email Ã‚Â¡Hola\!`
- International characters like `ñáéíóú` were showing as garbled text

## ✅ Solution

Implemented proper RFC 2047 encoding for email subjects to handle Unicode characters correctly.

### Changes Made:

1. **RFC 2047 Subject Encoding**: Format subjects as `=?UTF-8?B?${base64_encoded_subject}?=`
2. **Proper MIME Header Order**: Content-Type first, then MIME-Version
3. **Correct Transfer Encoding**: Use `7bit` encoding for better compatibility
4. **Standard Line Endings**: Use CRLF (`\r\n`) as per email standards
5. **Explicit UTF-8**: Specify encoding when creating message buffers

### Functions Updated:
- `send_email()` - Direct email sending
- `create_draft()` - Draft creation
- `find_and_draft_reply()` - Reply drafts

## 🧪 Testing

Tested with various characters:
- ✅ Emojis: 🚀 🤖 ✨ 🎉 📧 
- ✅ Accented: ñáéíóú àèìòù âêîôû
- ✅ Special: ¡¿¨´`~^°±×÷
- ✅ International scripts (Japanese, Arabic)

## 📚 Technical Details

The fix follows Gmail API best practices and RFC 2047 standards for handling non-ASCII characters in email headers. This ensures compatibility across all email clients and proper rendering of international content.

Resolves the Unicode corruption issue that was affecting email subject display.