### PR TITLE
docs: Fix OAuth client setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,17 @@ cp .env.example .env
 2. **Create OAuth client:**
    - Go to **APIs & Services** → **Credentials**
    - Click **+ CREATE CREDENTIALS** → **OAuth client ID**
-   - Application type: **Desktop app**
-   - Name: "Gmail MCP Desktop Client"
+   - Application type: **Web application** ⚠️ (NOT Desktop app)
+   - Name: "Gmail MCP Web Client"
+   - **Configure Authorized redirect URIs:**
+     - Click **+ ADD URI**
+     - Add: `http://localhost:8765/oauth2callback` (default port)
+     - If you plan to use a custom port, add: `http://localhost:YOUR_PORT/oauth2callback`
    - Click **Create**
    - **Download the credentials** (you'll see a download button or JSON option)
    - Save the `client_id` and `client_secret` from the downloaded file
+
+> **⚠️ Important**: Desktop app type doesn't allow custom redirect URIs, but we need `localhost:PORT/oauth2callback` for the OAuth flow to work. That's why we use **Web application** instead.
 
 ### 3. Generate Refresh Token
 
@@ -127,7 +133,11 @@ GMAIL_CLIENT_SECRET=your_client_secret_here
 GMAIL_REFRESH_TOKEN=
 # Security: Keep this false unless you need direct sending
 GMAIL_ALLOW_DIRECT_SEND=false
+# OAuth setup port (must match the redirect URI you configured above)
+OAUTH_REDIRECT_PORT=8765
 ```
+
+> **💡 Port Configuration**: The `OAUTH_REDIRECT_PORT` must match the port you configured in the Google Cloud Console redirect URI. If you used `http://localhost:8765/oauth2callback`, keep it as 8765. If you used a different port, update this value accordingly.
 
 2. **Run the setup script:**
 
@@ -376,6 +386,21 @@ Show me the full content of the most recent email from my boss
 - `GMAIL_CLIENT_SECRET` 
 - `GMAIL_REFRESH_TOKEN`
 - `GMAIL_ALLOW_DIRECT_SEND` (optional, defaults to `false`)
+- `OAUTH_REDIRECT_PORT` (optional, defaults to `8765`)
+
+#### ❌ Error: redirect_uri_mismatch
+
+**Problem:** OAuth setup fails with "The redirect URI in the request does not match the ones authorized for the OAuth client."
+
+**Solution:** 
+1. Go to Google Cloud Console → APIs & Services → Credentials
+2. Click on your OAuth client
+3. In "Authorized redirect URIs", ensure you have: `http://localhost:8765/oauth2callback`
+4. If using a custom port, add: `http://localhost:YOUR_PORT/oauth2callback`
+5. Make sure your `.env` file has the matching `OAUTH_REDIRECT_PORT=8765`
+6. **Important**: OAuth client must be **Web application** type, not Desktop app
+
+> This error commonly occurs when following old documentation that suggests using "Desktop app" type, which doesn't support custom redirect URIs.
 
 #### 🛡️ Security: Direct email sending is disabled
 


### PR DESCRIPTION
## 🚨 Critical Documentation Fix

The current OAuth setup instructions are **incorrect and cause setup failures** for new users.

## ❌ Problem

The README instructs users to create a **Desktop app** OAuth client:
```
Application type: Desktop app
```

**This doesn't work** because:
- Desktop app type doesn't allow configuring custom redirect URIs
- We need `http://localhost:8765/oauth2callback` for the OAuth flow
- Results in `redirect_uri_mismatch` error during setup

## ✅ Solution

### Updated Instructions:
1. **OAuth Client Type**: Changed from "Desktop app" to **"Web application"**
2. **Redirect URI Configuration**: Added required steps to configure `http://localhost:8765/oauth2callback`
3. **Port Relationship**: Clear connection between Google Console redirect URI and `OAUTH_REDIRECT_PORT`
4. **Troubleshooting**: New section for `redirect_uri_mismatch` error

### Key Changes:

#### Before (Broken):
```
- Application type: Desktop app  ❌
- Name: "Gmail MCP Desktop Client"
- Click Create
```

#### After (Working):
```
- Application type: Web application  ✅
- Name: "Gmail MCP Web Client"  
- Configure Authorized redirect URIs:
  - Add: http://localhost:8765/oauth2callback
- Click Create
```

## 📋 Additional Improvements

1. **Environment Configuration**: Added `OAUTH_REDIRECT_PORT` to .env example
2. **Port Matching**: Clear explanation that redirect URI must match environment port
3. **Troubleshooting Section**: New `redirect_uri_mismatch` error handling
4. **Warning Notes**: Explicit warnings about why Desktop app doesn't work

## 🎯 Impact

This fix prevents the **most common setup failure** new users encounter:
- ❌ Before: OAuth setup fails with cryptic errors
- ✅ After: OAuth setup works correctly on first try

## 🧪 Testing

This change resolves the exact issue we experienced during our own setup, where following the original instructions led to authentication failures.

## 📚 Context

Web application OAuth type is the correct choice for localhost-based OAuth flows that require custom redirect URIs. This is standard practice for development tools that need OAuth integration.

**Priority: High** - This prevents new users from being able to set up the tool at all.